### PR TITLE
Flawless static analysis workflows

### DIFF
--- a/.github/linters/phpstan.neon
+++ b/.github/linters/phpstan.neon
@@ -7,8 +7,10 @@ parameters:
     ignoreErrors:
       -
         message: '#Call to function is_null\(\) with Psr\\Log\\LoggerInterface will always evaluate to false.#'
-        path: /github/workspace/classes/BackyardBriefApiClient.php 
-      - '#Error: Class xmysqli not found.#'
+        path: ../../classes/BackyardBriefApiClient.php 
+      - 
+        message: '#Error: Class mysqli not found.#'
+        path: ../../classes/BackyardMysqli.php
     #  - '#Property WorkOfStan\\Backyard\\Backyard[a-zA-Z]+::\$BackyardError has unknown class Psr\\Log\\LoggerInterface as its type.#'
     #  - '#Property WorkOfStan\\Backyard\\Backyard[a-zA-Z]+::\$logger has unknown class Psr\\Log\\LoggerInterface as its type.#'
     #  - '#Parameter \$logger of method WorkOfStan\\Backyard\\Backyard[a-zA-Z0-9]+::__construct\(\) has invalid typehint type Psr\\Log\\LoggerInterface.#'

--- a/.github/linters/phpstan.neon
+++ b/.github/linters/phpstan.neon
@@ -8,6 +8,7 @@ parameters:
       -
         message: '#Call to function is_null\(\) with Psr\\Log\\LoggerInterface will always evaluate to false.#'
         path: /github/workspace/classes/BackyardBriefApiClient.php 
+      - '#Error: Class mysqli not found.#'
     #  - '#Property WorkOfStan\\Backyard\\Backyard[a-zA-Z]+::\$BackyardError has unknown class Psr\\Log\\LoggerInterface as its type.#'
     #  - '#Property WorkOfStan\\Backyard\\Backyard[a-zA-Z]+::\$logger has unknown class Psr\\Log\\LoggerInterface as its type.#'
     #  - '#Parameter \$logger of method WorkOfStan\\Backyard\\Backyard[a-zA-Z0-9]+::__construct\(\) has invalid typehint type Psr\\Log\\LoggerInterface.#'

--- a/.github/linters/phpstan.neon
+++ b/.github/linters/phpstan.neon
@@ -2,15 +2,19 @@ parameters:
     level: 5
     excludes_analyse:
       - ../../src/*.php
+    #Error message "Class mysqli not found." cannot be ignored, use excludes_analyse instead. # TODO fix this
+      - ../../classes/Backyard.php
+      - ../../classes/BackyardGeo.php
+      - ../../classes/BackyardMysqli.php
     scanDirectories:
       - ../../classes
     ignoreErrors:
       -
         message: '#Call to function is_null\(\) with Psr\\Log\\LoggerInterface will always evaluate to false.#'
         path: ../../classes/BackyardBriefApiClient.php 
-      - 
-        message: '#Class mysqli not found.#'
-        path: ../../classes/BackyardMysqli.php
+    #  - 
+    #    message: '#Class mysqli not found.#'
+    #    path: ../../classes/BackyardMysqli.php
     #  - '#Property WorkOfStan\\Backyard\\Backyard[a-zA-Z]+::\$BackyardError has unknown class Psr\\Log\\LoggerInterface as its type.#'
     #  - '#Property WorkOfStan\\Backyard\\Backyard[a-zA-Z]+::\$logger has unknown class Psr\\Log\\LoggerInterface as its type.#'
     #  - '#Parameter \$logger of method WorkOfStan\\Backyard\\Backyard[a-zA-Z0-9]+::__construct\(\) has invalid typehint type Psr\\Log\\LoggerInterface.#'

--- a/.github/linters/phpstan.neon
+++ b/.github/linters/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: max
+    level: 5
     excludes_analyse:
       - ../../src/*.php
     scanDirectories:
@@ -8,9 +8,9 @@ parameters:
       -
         message: '#Call to function is_null\(\) with Psr\\Log\\LoggerInterface will always evaluate to false.#'
         path: /github/workspace/classes/BackyardBriefApiClient.php 
-      - '#Property WorkOfStan\\Backyard\\Backyard[a-zA-Z]+::\$BackyardError has unknown class Psr\\Log\\LoggerInterface as its type.#'
-      - '#Property WorkOfStan\\Backyard\\Backyard[a-zA-Z]+::\$logger has unknown class Psr\\Log\\LoggerInterface as its type.#'
-      - '#Parameter \$logger of method WorkOfStan\\Backyard\\Backyard[a-zA-Z0-9]+::__construct\(\) has invalid typehint type Psr\\Log\\LoggerInterface.#'
-      - '#Call to method [a-z]+\(\) on an unknown class Psr\\Log\\LoggerInterface.#'
-      - '#Reflection error: Psr\\Log\\AbstractLogger not found.#'
-      - '#Reflection error: PHPUnit_Framework_TestCase not found.#'
+    #  - '#Property WorkOfStan\\Backyard\\Backyard[a-zA-Z]+::\$BackyardError has unknown class Psr\\Log\\LoggerInterface as its type.#'
+    #  - '#Property WorkOfStan\\Backyard\\Backyard[a-zA-Z]+::\$logger has unknown class Psr\\Log\\LoggerInterface as its type.#'
+    #  - '#Parameter \$logger of method WorkOfStan\\Backyard\\Backyard[a-zA-Z0-9]+::__construct\(\) has invalid typehint type Psr\\Log\\LoggerInterface.#'
+    #  - '#Call to method [a-z]+\(\) on an unknown class Psr\\Log\\LoggerInterface.#'
+    #  - '#Reflection error: Psr\\Log\\AbstractLogger not found.#'
+    #  - '#Reflection error: PHPUnit_Framework_TestCase not found.#'

--- a/.github/linters/phpstan.neon
+++ b/.github/linters/phpstan.neon
@@ -9,7 +9,7 @@ parameters:
         message: '#Call to function is_null\(\) with Psr\\Log\\LoggerInterface will always evaluate to false.#'
         path: ../../classes/BackyardBriefApiClient.php 
       - 
-        message: '#Error: Class mysqli not found.#'
+        message: '#Class mysqli not found.#'
         path: ../../classes/BackyardMysqli.php
     #  - '#Property WorkOfStan\\Backyard\\Backyard[a-zA-Z]+::\$BackyardError has unknown class Psr\\Log\\LoggerInterface as its type.#'
     #  - '#Property WorkOfStan\\Backyard\\Backyard[a-zA-Z]+::\$logger has unknown class Psr\\Log\\LoggerInterface as its type.#'

--- a/.github/linters/phpstan.neon
+++ b/.github/linters/phpstan.neon
@@ -8,7 +8,7 @@ parameters:
       -
         message: '#Call to function is_null\(\) with Psr\\Log\\LoggerInterface will always evaluate to false.#'
         path: /github/workspace/classes/BackyardBriefApiClient.php 
-      - '#Error: Class mysqli not found.#'
+      - '#Error: Class xmysqli not found.#'
     #  - '#Property WorkOfStan\\Backyard\\Backyard[a-zA-Z]+::\$BackyardError has unknown class Psr\\Log\\LoggerInterface as its type.#'
     #  - '#Property WorkOfStan\\Backyard\\Backyard[a-zA-Z]+::\$logger has unknown class Psr\\Log\\LoggerInterface as its type.#'
     #  - '#Parameter \$logger of method WorkOfStan\\Backyard\\Backyard[a-zA-Z0-9]+::__construct\(\) has invalid typehint type Psr\\Log\\LoggerInterface.#'

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -50,6 +50,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JAVASCRIPT_ES_CONFIG_FILE: .eslintrc.yml
           VALIDATE_JAVASCRIPT_STANDARD: false
+          VALIDATE_JSCPD: false
           VALIDATE_ANSIBLE: false
           VALIDATE_PHP_PSALM: false
           VALIDATE_HTML: false

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Lint Code Base
         uses: github/super-linter@master
         env:
-          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: develop
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JAVASCRIPT_ES_CONFIG_FILE: .eslintrc.yml

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -39,6 +39,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
 
+      # composer to provide context for PHPStan
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-progress --no-suggest
+
       ################################
       # Run Linter against code base #
       ################################

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -41,7 +41,7 @@ jobs:
 
       # composer to provide context for PHPStan
       - name: Install dependencies
-        run: composer update --prefer-dist --no-progress --no-suggest
+        run: "composer update --prefer-dist --no-progress --ignore-platform-req=php"
 
       ################################
       # Run Linter against code base #

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -7,7 +7,8 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: ubuntu-latest
+        operating-system:
+          - "ubuntu-latest"
         php-versions: ['5.3', '5.6', '7.3', '7.4']
 
     steps:

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -31,13 +31,15 @@ jobs:
     - name: Install dependencies
       run: composer update --prefer-dist --no-progress --no-suggest
 
-    - name: PHPUnit (php-actions)
-      uses: php-actions/phpunit@v5
-      with:
-        # PHP included in ubuntu-latest does not support iconv //TRANSLIT flag as iconv implementation is unknown
-        # https://github.com/actions/virtual-environments/blob/ubuntu18/20201026.1/images/linux/Ubuntu1804-README.md
-        # therefore PHPUnit group iconvtranslit should be excluded
-        configuration: phpunit.xml
+    - name: "PHPUnit tests"
+      run: "vendor/bin/phpunit"
+    #- name: PHPUnit (php-actions)
+    #  uses: php-actions/phpunit@v5
+    #  with:
+    #    # PHP included in ubuntu-latest does not support iconv //TRANSLIT flag as iconv implementation is unknown
+    #    # https://github.com/actions/virtual-environments/blob/ubuntu18/20201026.1/images/linux/Ubuntu1804-README.md
+    #    # therefore PHPUnit group iconvtranslit should be excluded
+    #    configuration: phpunit.xml
 
     # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
     # Docs: https://getcomposer.org/doc/articles/scripts.md

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -9,13 +9,13 @@ jobs:
       matrix:
         operating-system:
           - "ubuntu-latest"
-        php-versions: ['5.3', '5.6', '7.3', '7.4']
+        php-version: ['5.3', '5.6', '7.3', '7.4']
 
     steps:
     - name: "Checkout"        
       uses: actions/checkout@v2
 
-    - name: "Install PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}"
+    - name: "Install PHP ${{ matrix.php-version }} Test on ${{ matrix.operating-system }}"
       uses: "shivammathur/setup-php@v2"
       with:
         php-version: "${{ matrix.php-version }}"

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -4,19 +4,31 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: ubuntu-latest
+        php-versions: ['5.3', '5.6', '7.3', '7.4']
 
     steps:
-    - uses: actions/checkout@v2
+    - name: "Checkout"        
+      uses: actions/checkout@v2
+
+    - name: "Install PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}"
+      uses: "shivammathur/setup-php@v2"
+      with:
+        php-version: "${{ matrix.php-version }}"
+        tools: composer:v2, phpunit
+        # tools: composer:v2, phpunit
 
     - name: Validate composer.json and composer.lock
       run: composer validate
 
     - name: Install no-dev dependencies
-      run: composer update --no-dev --prefer-dist --no-progress
+      run: composer update --no-dev --prefer-dist --no-progress --no-suggest
 
     - name: Install dependencies
-      run: composer update --prefer-dist --no-progress
+      run: composer update --prefer-dist --no-progress --no-suggest
 
     - name: PHPUnit (php-actions)
       uses: php-actions/phpunit@v5

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -26,10 +26,10 @@ jobs:
       run: composer validate
 
     - name: Install no-dev dependencies
-      run: composer update --no-dev --prefer-dist --no-progress --no-suggest
+      run: composer update --no-dev --prefer-dist --no-progress
 
     - name: Install dependencies
-      run: composer update --prefer-dist --no-progress --no-suggest
+      run: composer update --prefer-dist --no-progress
 
     - name: "PHPUnit tests"
       run: "vendor/bin/phpunit"

--- a/classes/Backyard.php
+++ b/classes/Backyard.php
@@ -7,7 +7,7 @@ class Backyard
 
     /**
      *
-     * @var array
+     * @var array<mixed> int,string,bool,array
      */
     protected $BackyardConf = array();
 
@@ -61,7 +61,7 @@ class Backyard
 
     /**
      *
-     * @param array $backyardConfConstruct
+     * @param array<mixed> $backyardConfConstruct contains int,string,bool,array
      */
     public function __construct(array $backyardConfConstruct = array())
     {

--- a/classes/BackyardError.php
+++ b/classes/BackyardError.php
@@ -222,11 +222,13 @@ class BackyardError extends AbstractLogger implements LoggerInterface
 
         if (
             (
-                $level <= max(array(
-                $this->backyardConf['logging_level'],
-                $this->backyardConf['error_hack_from_get'], //set potentially as GET parameter
-                $ERROR_HACK, //set as variable in the application script
-            ))
+                $level <= max(
+                    array(
+                        $this->backyardConf['logging_level'],
+                        $this->backyardConf['error_hack_from_get'], //set potentially as GET parameter
+                        $ERROR_HACK, //set as variable in the application script
+                    )
+                )
             ) //to log 0=unknown/default 1=fatal 2=error 3=warning 4=info 5=debug 6=speed according to $level
             || (($error_number == "6") && ($this->backyardConf['logging_level_page_speed'] <= $this->backyardConf['logging_level'])) //speed logovat vždy když je ukázaná, resp. dle nastavení $logging_level_page_speed
         ) {

--- a/classes/BackyardError.php
+++ b/classes/BackyardError.php
@@ -10,8 +10,17 @@ class BackyardError extends AbstractLogger implements LoggerInterface
 {
 
 // phpcs:disable Generic.Files.LineLength
+
+    /**
+     *
+     * @var array<mixed> int,string,bool,array
+     */
     protected $backyardConf = array();
 
+    /**
+     *
+     * @var BackyardTime
+     */
     protected $backyardTime;
 
     /**
@@ -213,7 +222,7 @@ class BackyardError extends AbstractLogger implements LoggerInterface
 
         if (
             (
-            $level <= max(array(
+                $level <= max(array(
                 $this->backyardConf['logging_level'],
                 $this->backyardConf['error_hack_from_get'], //set potentially as GET parameter
                 $ERROR_HACK, //set as variable in the application script

--- a/classes/BackyardMysqli.php
+++ b/classes/BackyardMysqli.php
@@ -91,7 +91,7 @@ class BackyardMysqli extends \mysqli
      * @param int $errorLogOutput optional default=1 turn-off=0
      *   It is int in order to be compatible with
      *   parameter $resultmode (int) of method mysqli::query()
-     * @return bool|\mysqli_result \mysqli_result|false
+     * @return \mysqli_result|false
      */
     public function query($sql, $errorLogOutput = 1)
     {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 5
+    level: 6
     excludePaths:
         analyse:
           - vendor

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,4 +10,5 @@ parameters:
     ignoreErrors:
       -
         message: '#Call to function is_null\(\) with Psr\\Log\\LoggerInterface will always evaluate to false.#'
-        path: classes/BackyardBriefApiClient.php 
+        path: classes/BackyardBriefApiClient.php
+      - '#Reflection error: PHPUnit_Framework_TestCase not found.#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: max
+    level: 5
     excludePaths:
         analyse:
           - vendor

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 6
+    level: 5
     excludePaths:
         analyse:
           - vendor

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 5
+    level: max
     excludePaths:
         analyse:
           - vendor
@@ -11,4 +11,4 @@ parameters:
       -
         message: '#Call to function is_null\(\) with Psr\\Log\\LoggerInterface will always evaluate to false.#'
         path: classes/BackyardBriefApiClient.php
-      - '#Reflection error: PHPUnit_Framework_TestCase not found.#'
+    #  - '#Reflection error: PHPUnit_Framework_TestCase not found.#'

--- a/super-linter.report/.htaccess
+++ b/super-linter.report/.htaccess
@@ -1,0 +1,2 @@
+Order Allow,Deny
+Deny from all


### PR DESCRIPTION
* composer (--ignore-platform-req=php) to provide context for PHPStan on-line as part of super-linter, see https://github.com/phpstan/phpstan/discussions/4677
* super-linter PHPStan workaround: Error message "Class mysqli not found." cannot be ignored, use excludes_analyse instead.
* super-linter.report folder for super-linter reports (but nothing is saved there anyway?)
* composer dependencies and PHPUnit tested with matrix strategy: php-versions: ['5.3', '5.6', '7.3', '7.4']
