### PR TITLE
BackyardArray may use `\Psr\Log\NullLogger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
+## [3.4.2] - 2024-08-03
+### Changed
+- BackyardArray accepts null as logger => `\Psr\Log\NullLogger`
+- BackyardHttp::movePage - extended array with additional HTTP status codes
+
 ## [3.4.1] - 2024-08-03
 ### Fixed
 - BackyardBriefApiClient, BackyardGeo, BackyardJson typehinted and method parameters checked for validity
@@ -252,7 +257,9 @@ LIBrary in backyard 2.0.0
 - fix for post functionality in backyard_getData
 
 
-[Unreleased]: https://github.com/WorkOfStan/backyard/compare/v3.4.0...HEAD
+[Unreleased]: https://github.com/WorkOfStan/backyard/compare/v3.4.2...HEAD
+[3.4.2]: https://github.com/WorkOfStan/backyard/compare/v3.4.1...v3.4.2
+[3.4.1]: https://github.com/WorkOfStan/backyard/compare/v3.4.0...v3.4.1
 [3.4.0]: https://github.com/WorkOfStan/backyard/compare/v3.3.2...v3.4.0
 [3.3.2]: https://github.com/WorkOfStan/backyard/compare/v3.3.1...v3.3.2
 [3.3.1]: https://github.com/WorkOfStan/backyard/compare/v3.3.0...v3.3.1

--- a/classes/BackyardArray.php
+++ b/classes/BackyardArray.php
@@ -16,9 +16,9 @@ class BackyardArray
      *
      * @param LoggerInterface $logger
      */
-    public function __construct(LoggerInterface $logger)
+    public function __construct(LoggerInterface $logger = null)
     {
-        $this->logger = $logger;
+        $this->logger = is_null($logger) ? new \Psr\Log\NullLogger() : $logger;
     }
     /**
      * Note http://php.net/manual/en/function.array-key-exists.php#107786

--- a/classes/BackyardBriefApiClient.php
+++ b/classes/BackyardBriefApiClient.php
@@ -2,9 +2,9 @@
 
 namespace WorkOfStan\Backyard;
 
-use UnexpectedValueException;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use UnexpectedValueException;
 
 /**
  * Very simple JSON RESTful API client

--- a/classes/BackyardHttp.php
+++ b/classes/BackyardHttp.php
@@ -66,6 +66,8 @@ class BackyardHttp
         static $http = array(
             100 => "HTTP/1.1 100 Continue",
             101 => "HTTP/1.1 101 Switching Protocols",
+            102 => "HTTP/1.1 102 Processing",
+            103 => "HTTP/1.1 103 Early Hints",
             200 => "HTTP/1.1 200 OK",
             201 => "HTTP/1.1 201 Created",
             202 => "HTTP/1.1 202 Accepted",
@@ -73,6 +75,9 @@ class BackyardHttp
             204 => "HTTP/1.1 204 No Content",
             205 => "HTTP/1.1 205 Reset Content",
             206 => "HTTP/1.1 206 Partial Content",
+            207 => "HTTP/1.1 207 Multi-Status",
+            208 => "HTTP/1.1 208 Already Reported",
+            226 => "HTTP/1.1 226 IM Used",
             300 => "HTTP/1.1 300 Multiple Choices",
             301 => "HTTP/1.1 301 Moved Permanently",
             302 => "HTTP/1.1 302 Found",
@@ -80,6 +85,7 @@ class BackyardHttp
             304 => "HTTP/1.1 304 Not Modified",
             305 => "HTTP/1.1 305 Use Proxy",
             307 => "HTTP/1.1 307 Temporary Redirect",
+            308 => "HTTP/1.1 308 Permanent Redirect",
             400 => "HTTP/1.1 400 Bad Request",
             401 => "HTTP/1.1 401 Unauthorized",
             402 => "HTTP/1.1 402 Payment Required",
@@ -96,13 +102,30 @@ class BackyardHttp
             413 => "HTTP/1.1 413 Request Entity Too Large",
             414 => "HTTP/1.1 414 Request-URI Too Large",
             415 => "HTTP/1.1 415 Unsupported Media Type",
-            416 => "HTTP/1.1 416 Requested range not satisfiable",
+            416 => "HTTP/1.1 416 Requested Range Not Satisfiable",
             417 => "HTTP/1.1 417 Expectation Failed",
+            418 => "HTTP/1.1 418 I'm a teapot",
+            421 => "HTTP/1.1 421 Misdirected Request",
+            422 => "HTTP/1.1 422 Unprocessable Entity",
+            423 => "HTTP/1.1 423 Locked",
+            424 => "HTTP/1.1 424 Failed Dependency",
+            425 => "HTTP/1.1 425 Too Early",
+            426 => "HTTP/1.1 426 Upgrade Required",
+            428 => "HTTP/1.1 428 Precondition Required",
+            429 => "HTTP/1.1 429 Too Many Requests",
+            431 => "HTTP/1.1 431 Request Header Fields Too Large",
+            451 => "HTTP/1.1 451 Unavailable For Legal Reasons",
             500 => "HTTP/1.1 500 Internal Server Error",
             501 => "HTTP/1.1 501 Not Implemented",
             502 => "HTTP/1.1 502 Bad Gateway",
             503 => "HTTP/1.1 503 Service Unavailable",
-            504 => "HTTP/1.1 504 Gateway Time-out"
+            504 => "HTTP/1.1 504 Gateway Time-out",
+            505 => "HTTP/1.1 505 HTTP Version Not Supported",
+            506 => "HTTP/1.1 506 Variant Also Negotiates",
+            507 => "HTTP/1.1 507 Insufficient Storage",
+            508 => "HTTP/1.1 508 Loop Detected",
+            510 => "HTTP/1.1 510 Not Extended",
+            511 => "HTTP/1.1 511 Network Authentication Required"
         );
         header($http[$num]);
         header("Location: {$url}");
@@ -149,7 +172,7 @@ class BackyardHttp
             ((!$isHTTPS && $_SERVER["SERVER_PORT"] != "80") || ($isHTTPS && $_SERVER["SERVER_PORT"] != "443"))) //
             ? ':' . $_SERVER["SERVER_PORT"] : '') // port
             . (
-                $includeTheQueryPart ? $_SERVER["REQUEST_URI"] // including RewriteRule result
+            $includeTheQueryPart ? $_SERVER["REQUEST_URI"] // including RewriteRule result
             : $_SERVER["SCRIPT_NAME"] // without the query part and RewriteRule result
             ) //endGame
         ;

--- a/classes/BackyardMysqli.php
+++ b/classes/BackyardMysqli.php
@@ -2,8 +2,8 @@
 
 namespace WorkOfStan\Backyard;
 
-use WorkOfStan\Backyard\BackyardError;
 use Psr\Log\NullLogger;
+use WorkOfStan\Backyard\BackyardError;
 
 /* * ****************************************************************************
  * Database (MySQL) FUNCTIONS


### PR DESCRIPTION
### Changed
- BackyardArray accepts null as logger => `\Psr\Log\NullLogger`
- BackyardHttp::movePage - extended array with additional HTTP status codes