### PR TITLE
fix: remove parameter typing in `BackyardMysqli::query()` in order to be backward compatible

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,5 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every month
       interval: "monthly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
   php-composer-unit-stan:
-    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@feature/super-linter-850
+    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.8
     with:
       # JSON
       php-version: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5."]'
@@ -65,7 +65,6 @@ jobs:
 
   super-linter:
     needs: phpcs-phpcbf
-    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@feature/super-linter-850
+    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.8
     with:
       runs-on: "ubuntu-latest"
-      validate-spell-codespell: true

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
   php-composer-unit-stan:
-    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.7
+    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@feature/super-linter-850
     with:
       # JSON
       php-version: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5."]'
@@ -65,6 +65,7 @@ jobs:
 
   super-linter:
     needs: phpcs-phpcbf
-    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.7
+    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@feature/super-linter-850
     with:
       runs-on: "ubuntu-latest"
+      validate-spell-codespell: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
+## [4.1.2.1] - 2026-02-08
+
+fix: remove parameter typing in `BackyardMysqli::query()` in order to be backward compatible
+
 ## [4.1.2] - 2025-12-28
 
 feat: add PHP/8.5 support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
-## [4.1.2.1] - 2026-02-08
+## [4.1.2.1] - 2026-02-14
 
 fix: remove parameter typing in `BackyardMysqli::query()` in order to be backward compatible
+
+### Changed
+
+- ci(super-linter): bump to v8.5.0
 
 ### Fixed
 
@@ -379,7 +383,8 @@ LIBrary in backyard 2.0.0
 
 - fix for post functionality in backyard_getData
 
-[Unreleased]: https://github.com/WorkOfStan/backyard/compare/v4.1.2...HEAD
+[Unreleased]: https://github.com/WorkOfStan/backyard/compare/v4.1.2.1...HEAD
+[4.1.2.1]: https://github.com/WorkOfStan/backyard/compare/v4.1.2...v4.1.2.1
 [4.1.2]: https://github.com/WorkOfStan/backyard/compare/v4.1.1...v4.1.2
 [4.1.1]: https://github.com/WorkOfStan/backyard/compare/v4.1.0...v4.1.1
 [4.1.0]: https://github.com/WorkOfStan/backyard/compare/v4.0.0...v4.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 fix: remove parameter typing in `BackyardMysqli::query()` in order to be backward compatible
 
+### Fixed
+
+- fix: remove parameter typing in `BackyardMysqli::query()` in order to be backward compatible
+- ci(PHPUnit): fix preventing running HTTP tests on GitHub
+
 ## [4.1.2] - 2025-12-28
 
 feat: add PHP/8.5 support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ fix: remove parameter typing in `BackyardMysqli::query()` in order to be backwar
 ### Fixed
 
 - fix: remove parameter typing in `BackyardMysqli::query()` in order to be backward compatible
-- ci(PHPUnit): fix preventing running HTTP tests on GitHub
+- ci(PHPUnit): add a workaround to prevent running HTTP tests on GitHub which works for PHP/7.4-8.5 (i.e. PHPUnit/8-12)
 
 ## [4.1.2] - 2025-12-28
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $backyard = new \WorkOfStan\Backyard\Backyard(
         //logger relevant other
         'logging_level_name'        => array(0 => 'unknown', 1 => 'fatal', 'error', 'warning', 'info', 'debug', 'speed'),
         'logging_level_page_speed'  => 5,       //úroveň logování, do které má být zapisována rychlost vygenerování stránky
-        'die_graciously_verbose'    => true,    //show details by die_graciously() on screen (it is always in the error_log); on production it is recomended to be set to to false due security
+        'die_graciously_verbose'    => true,    //show details by die_graciously() on screen (it is always in the error_log); on production it is recommended to be set to to false due security
         'log_monthly_rotation'      => true,    //true, pokud má být přípona .log.Y-m.log (výhodou je měsíční rotace); false, pokud má být jen .log (výhodou je sekvenční zápis chyb přes my_error_log a jiných PHP chyb)
         'log_profiling_step'        => false,   //110812, my_error_log neprofiluje rychlost //$PROFILING_STEP = 0.008;//110812, my_error_log profiluje čas mezi dvěma měřenými body vyšší než udaná hodnota sec
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 ## Requirements
 
 - [PHP 5.3.0 or higher](http://www.php.net/) (i.e. not used [] instead of array() as this short syntax can be used only since PHP 5.4)
+  - workofstan/backyard:^4.1.2 `php: >=7.4 <8.6`
+  - workofstan/backyard:3.4.3: `php: >=5.3, <7.4`
 
 ## Installation
 
@@ -24,7 +26,7 @@ composer installed.
 Once composer is installed, execute the following command in your project root to install this library:
 
 ```sh
-composer require workofstan/backyard:^4.1.2
+composer require workofstan/backyard:^4.1.2.1
 ```
 
 Finally, be sure to include the autoloader:

--- a/classes/BackyardArray.php
+++ b/classes/BackyardArray.php
@@ -134,7 +134,7 @@ class BackyardArray
     }
 
     /**
-     * Returns first row with exact match //@TODO 4 - přidat parametr na vrácení všech rows s exact match
+     * Returns first row with exact match //@TODO 4 - add a parameter to return all rows with an exact match
      * Useful for at least 2-dimensional arrays
      *
      * @param mixed $searchedValue

--- a/classes/BackyardError.php
+++ b/classes/BackyardError.php
@@ -33,7 +33,7 @@ class BackyardError extends Logger implements LoggerInterface
                 'logging_file' => '', //soubor, do kterého má my_error_log() zapisovat
                 'logging_level_page_speed' => 5, //úroveň logování, do které má být zapisována rychlost vygenerování stránky
                 'error_log_message_type' => 0, //parameter message_type http://cz2.php.net/manual/en/function.error-log.php for my_error_log; default is 0, i.e. to send message to PHP's system logger; recommended is however 3, i.e. append to the file destination set either in field $this->BackyardConf['logging_file or in table system
-                'die_graciously_verbose' => true, //show details by die_graciously() on screen (it is always in the error_log); on production it is recomended to be set to to false due security
+                'die_graciously_verbose' => true, //show details by die_graciously() on screen (it is always in the error_log); on production it is recommended to be set to to false due security
                 'mail_for_admin_enabled' => false, //fatal error may just be written in log //$backyardMailForAdminEnabled = "rejthar@gods.cz";//on production, it is however recommended to set an e-mail, where to announce fatal errors
                 'log_monthly_rotation' => true, //true, pokud má být přípona .log.Y-m.log (výhodou je měsíční rotace); false, pokud má být jen .log (výhodou je sekvenční zápis chyb přes my_error_log a jiných PHP chyb)
                 'log_standard_output' => false, //true, pokud má zároveň vypisovat na obrazovku; false, pokud má vypisovat jen do logu

--- a/classes/BackyardJson.php
+++ b/classes/BackyardJson.php
@@ -52,7 +52,7 @@ class BackyardJson
      * @param int $logLevel - optional - default is not to be verbose
      * @return string minified JSON (works only if $exitAfterOuput === false)
      *
-     * @todo - add posibility to return HTTP status codes other than 200
+     * @todo - add possibility to return HTTP status codes other than 200
      */
     public function outputJSON($jsonString, $exitAfterOutput = false, $logLevel = 5)
     {

--- a/classes/BackyardMysqli.php
+++ b/classes/BackyardMysqli.php
@@ -88,6 +88,9 @@ class BackyardMysqli extends \mysqli
      * @param int $errorLogOutput optional default=1 turn-off=0
      *   It is int in order to be compatible with
      *   parameter $resultmode (int) of method mysqli::query()
+     *   Note: don't use type int next to parameter, otherwise triggered PHP Warning:
+     *   Declaration of WorkOfStan\Backyard\BackyardMysqli::query($sql, int $errorLogOutput = 1) should be compatible
+     *   with mysqli::query($query, $resultmode = NULL)
      * @return bool|\mysqli_result<object>
      *   <p>Returns <b><code>FALSE</code></b> on failure. For successful <i>SELECT, SHOW, DESCRIBE</i> or <i>EXPLAIN</i>
      *   queries <b>mysqli_query()</b> will return a mysqli_result object.
@@ -98,7 +101,7 @@ class BackyardMysqli extends \mysqli
      * Make it covariant, or use the #[\ReturnTypeWillChange] attribute to temporarily suppress the error.
      */
     #[\ReturnTypeWillChange]
-    public function query($sql, int $errorLogOutput = 1)
+    public function query($sql, $errorLogOutput = 1)
     {
         $ERROR_LOG_OUTPUT = (bool) $errorLogOutput;
         if ($ERROR_LOG_OUTPUT) {

--- a/classes/BackyardMysqli.php
+++ b/classes/BackyardMysqli.php
@@ -10,7 +10,7 @@ use WorkOfStan\Backyard\BackyardError;
  *
  * TODO create TestBackyardMysqli.php
  * TODO compare admins vs user for throw new \Exception vs dieGraciously and if migrated to Exception:
- * use Psr\Log\LoggerInterface instad of WorkOfStan\Backyard\BackyardError
+ * use Psr\Log\LoggerInterface instead of WorkOfStan\Backyard\BackyardError
  *
  */
 

--- a/conf/phpunit-github.xml
+++ b/conf/phpunit-github.xml
@@ -2,9 +2,6 @@
 <phpunit
     colors="true"
     stderr="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     stopOnFailure="false">
     <testsuites>
         <testsuite name="Application Test Suite">
@@ -15,7 +12,6 @@
     <groups>
       <exclude>
         <group>http</group>
-        <file>tests/BackyardHttpTest.php</file>
       </exclude>
     </groups>
 </phpunit>

--- a/conf/phpunit-github.xml
+++ b/conf/phpunit-github.xml
@@ -15,6 +15,7 @@
     <groups>
       <exclude>
         <group>http</group>
+        <file>tests/BackyardHttpTest.php</file>
       </exclude>
     </groups>
 </phpunit>

--- a/sql/poi.sql
+++ b/sql/poi.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS `poi_category` (
     `id` int(11) NOT NULL,
     `name` varchar(100) COLLATE utf8_czech_ci NOT NULL
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8 COLLATE = utf8_czech_ci
-COMMENT = 'Naming of poi catgories for table poi_list';
+COMMENT = 'Naming of poi categories for table poi_list';
 
 
 --

--- a/tests/BackyardHttpTest.php
+++ b/tests/BackyardHttpTest.php
@@ -2,6 +2,7 @@
 
 namespace WorkOfStan\Backyard\Tests;
 
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Webmozart\Assert\Assert;
 use Webmozart\Assert\InvalidArgumentException;
@@ -83,10 +84,10 @@ class BackyardHttpTest extends TestCase
     /**
      * @covers WorkOfStan\Backyard\BackyardHttp::getData
      * @group http
-     * #[Group('http')]
      *
      * @return void
      */
+    #[Group('http')]
     public function testGetDataContent(): void
     {
         $url = 'http://dadastrip.cz/test/';
@@ -139,9 +140,9 @@ class BackyardHttpTest extends TestCase
     /**
      * @covers WorkOfStan\Backyard\BackyardHttp::getData
      * @group http
-     * #[Group('http')]
      * @return void
      */
+    #[Group('http')]
     public function testGetDataRedirect(): void
     {
         //@todo incl. recursion (if there is)

--- a/tests/BackyardHttpTest.php
+++ b/tests/BackyardHttpTest.php
@@ -87,9 +87,12 @@ class BackyardHttpTest extends TestCase
      *
      * @return void
      */
-    #[Group('http')]
+    //#[Group('http')] // available for PHPUnit/10+
     public function testGetDataContent(): void
     {
+        if (getenv('GITHUB_ACTIONS') === 'true') {
+            $this->markTestSkipped('This test does not run on GitHub Actions.');
+        }
         $url = 'http://dadastrip.cz/test/';
         $useragent = 'PHP/phpunit-testing';
         $timeout = 5;
@@ -142,9 +145,12 @@ class BackyardHttpTest extends TestCase
      * @group http
      * @return void
      */
-    #[Group('http')]
+    //#[Group('http')] // available for PHPUnit/10+
     public function testGetDataRedirect(): void
     {
+        if (getenv('GITHUB_ACTIONS') === 'true') {
+            $this->markTestSkipped('This test does not run on GitHub Actions.');
+        }
         //@todo incl. recursion (if there is)
         $url = 'http://dadastrip.cz/test';
         $expected = array(

--- a/tests/BackyardHttpTest.php
+++ b/tests/BackyardHttpTest.php
@@ -2,7 +2,7 @@
 
 namespace WorkOfStan\Backyard\Tests;
 
-use PHPUnit\Framework\Attributes\Group;
+// use PHPUnit\Framework\Attributes\Group; // available for PHPUnit/10+
 use PHPUnit\Framework\TestCase;
 use Webmozart\Assert\Assert;
 use Webmozart\Assert\InvalidArgumentException;


### PR DESCRIPTION
### Changed

- ci(super-linter): bump to v8.5.0

### Fixed

- fix: remove parameter typing in `BackyardMysqli::query()` in order to be backward compatible
- ci(PHPUnit): add a workaround to prevent running HTTP tests on GitHub which works for PHP/7.4-8.5 (i.e. PHPUnit/8-12)
