### PR TITLE
chore: bump seablast/logger to 2.0.5

### DIFF
--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
   php-composer-unit-stan:
-    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.8
+    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.9
     with:
       # JSON
       php-version: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5."]'
@@ -65,6 +65,6 @@ jobs:
 
   super-linter:
     needs: phpcs-phpcbf
-    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.8
+    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.9
     with:
       runs-on: "ubuntu-latest"

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -27,7 +27,7 @@ jobs:
     uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.9
     with:
       # JSON
-      php-version: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5."]'
+      php-version: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]'
       # OPTIONAL path with the default database configuration
       phinx-config: "./conf/phinx.dist.php"
       # OPTIONAL path where the app code is looking for the database configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
+## [4.1.2.2] - 2026-03-08
+
+chore: bump seablast/logger to 2.0.5
+
+### Changed
+
+- bump seablast/logger to a version using typed properties internally
+
 ## [4.1.2.1] - 2026-02-14
 
 fix: remove parameter typing in `BackyardMysqli::query()` in order to be backward compatible
@@ -383,7 +391,8 @@ LIBrary in backyard 2.0.0
 
 - fix for post functionality in backyard_getData
 
-[Unreleased]: https://github.com/WorkOfStan/backyard/compare/v4.1.2.1...HEAD
+[Unreleased]: https://github.com/WorkOfStan/backyard/compare/v4.1.2.2...HEAD
+[4.1.2.2]: https://github.com/WorkOfStan/backyard/compare/v4.1.2.1...v4.1.2.2
 [4.1.2.1]: https://github.com/WorkOfStan/backyard/compare/v4.1.2...v4.1.2.1
 [4.1.2]: https://github.com/WorkOfStan/backyard/compare/v4.1.1...v4.1.2
 [4.1.1]: https://github.com/WorkOfStan/backyard/compare/v4.1.0...v4.1.1

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Stanislav Rejthar
+Copyright (c) 2014-2026 Stanislav Rejthar
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,13 +4,12 @@
 
 [![Total Downloads](https://img.shields.io/packagist/dt/workofstan/backyard.svg)](https://packagist.org/packages/workofstan/backyard)
 [![Latest Stable Version](https://img.shields.io/packagist/v/workofstan/backyard.svg)](https://packagist.org/packages/workofstan/backyard)
-[![Lint Code Base](https://github.com/WorkOfStan/backyard/actions/workflows/linter.yml/badge.svg)](https://github.com/WorkOfStan/backyard/actions/workflows/linter.yml)
-[![PHP Composer + PHPUnit + PHPStan](https://github.com/WorkOfStan/backyard/actions/workflows/php-composer-dependencies.yml/badge.svg)](https://github.com/WorkOfStan/backyard/actions/workflows/php-composer-dependencies.yml)
+[![Polish the code](https://github.com/WorkOfStan/backyard/actions/workflows/polish-the-code.yml/badge.svg)](https://github.com/WorkOfStan/backyard/actions/workflows/polish-the-code.yml)
 
 ## Requirements
 
 - [PHP 5.3.0 or higher](http://www.php.net/) (i.e. not used [] instead of array() as this short syntax can be used only since PHP 5.4)
-  - workofstan/backyard:^4.1.2 `php: >=7.4 <8.6`
+  - workofstan/backyard:^4.1.2.2 `php: >=7.4 <8.6`
   - workofstan/backyard:3.4.3: `php: >=5.3, <7.4`
 
 ## Installation
@@ -26,7 +25,7 @@ composer installed.
 Once composer is installed, execute the following command in your project root to install this library:
 
 ```sh
-composer require workofstan/backyard:^4.1.2.1
+composer require workofstan/backyard:^4.1.2.2
 ```
 
 Finally, be sure to include the autoloader:
@@ -88,7 +87,7 @@ Example of usage:
 ```php
 $backyard = new WorkOfStan\Backyard\Backyard(array('logging_level' => 3));
 $logger = $backyard->BackyardError;
-$dbLink = new WorkOfStan\Backyard\BackyardMysqli(DB_HOST, DB_USER, DB_PASSWORD, DB_DATABASE, $logger);
+$dbConnection = new WorkOfStan\Backyard\BackyardMysqli(DB_HOST, DB_USER, DB_PASSWORD, DB_DATABASE, $logger);
 ```
 
 ## class BackyardBriefApiClient

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
   "require": {
     "php": ">=7.4 <8.6",
     "ext-curl": "*",
-    "seablast/logger": "^2.0"
+    "seablast/logger": "dev-feature/typed-logger-from-fix"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.4 || ^9 || ^10 || ^11 || ^12",
-    "webmozart/assert": "^1.10.1"
+    "phpunit/phpunit": "^9.6.33 || ^10 || ^11 || ^12 || ^13",
+    "webmozart/assert": "^1.10.1 || ^2.1.6"
   },
   "minimum-stability": "stable",
   "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
   "require": {
     "php": ">=7.4 <8.6",
     "ext-curl": "*",
-    "seablast/logger": "dev-feature/typed-logger-from-fix"
+    "seablast/logger": "^2.0.5"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.6.33 || ^10 || ^11 || ^12 || ^13",
-    "webmozart/assert": "^1.10.1 || ^2.1.6"
+    "webmozart/assert": "^1.10 || ^2.1.6"
   },
   "minimum-stability": "stable",
   "prefer-stable": true,


### PR DESCRIPTION
### Changed

- bump seablast/logger to a version using typed properties internally