### PR TITLE
feat: add charset option to `BackyardMysqli`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 # Temporary files
 /.php_cs.cache
 /.phpunit.result.cache
+/.composer-cache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,99 @@
+# AGENTS.md
+
+## Project overview
+
+`workofstan/backyard` is a Composer PHP library of utility classes under `WorkOfStan\Backyard`: array helpers, JSON helpers, HTTP/cURL helpers, logging/error handling around `seablast/logger`, simple random IDs, string transliteration, time helpers, a `mysqli` wrapper, geo/POI lookup helpers, and legacy HTML/WML page output.
+
+## Setup
+
+Use a working Composer installation:
+
+```sh
+composer install
+```
+
+This repository has no required build step beyond installing Composer dependencies.
+
+## Test commands
+
+Run the PHPUnit suite:
+
+```sh
+vendor/bin/phpunit
+```
+
+On Windows PowerShell:
+
+```powershell
+.\vendor\bin\phpunit
+```
+
+Run the GitHub-style PHPUnit config that excludes `@group http` tests:
+
+```sh
+vendor/bin/phpunit -c conf/phpunit-github.xml
+```
+
+Run PHPStan through the project helper. On Windows, do not run `.sh` helper scripts directly from PowerShell; use Git Bash explicitly:
+
+```powershell
+& "C:\Program Files\Git\bin\bash.exe" -lc "./blast.sh phpstan"
+```
+
+Cleanup the temporary PHPStan packages:
+
+```powershell
+& "C:\Program Files\Git\bin\bash.exe" -lc "./blast.sh phpstan-remove"
+```
+
+Missing local aliases/tools:
+
+- No `composer test` script is defined.
+- PHPStan is not a committed dev dependency; `blast.sh phpstan` installs it temporarily.
+- PHPCS config exists in `.github/linters/phpcs.xml`, but PHPCS is not a Composer dev dependency. CI runs PHPCS through `WorkOfStan/phpcs-fix`.
+
+## Coding rules
+
+- PHP compatibility is `>=7.4 <8.6`; do not silently raise the minimum PHP version.
+- Namespace production classes as `WorkOfStan\Backyard` and place them in `classes/`.
+- Namespace tests as `WorkOfStan\Backyard\Tests` and place them in `tests/`.
+- Follow the existing PSR-12-ish formatting and the local preference for `array()` syntax.
+- Many public methods are intentionally loosely typed for compatibility. Add native parameter or return types only when the compatibility impact is clear.
+- Preserve existing comments. Remove a TODO only when you actually solve it; translating comments to English is acceptable when meaning is preserved.
+- Error handling is mixed: some methods throw built-in exceptions, some return `false` or `0`, and some log, echo, send headers, `exit`, or `die`. Preserve current behavior unless the task explicitly asks to change it.
+- Avoid new runtime dependencies unless clearly justified. Prefer standard PHP and existing Composer dependencies.
+
+## Change rules for AI agents
+
+- Prefer small, reviewable changes.
+- Do not change public API unless the task explicitly asks for it.
+- When fixing a bug, add or update a regression test.
+- Preserve backward compatibility unless instructed otherwise.
+- Do not silently raise the minimum PHP version.
+- Do not replace existing architecture with a new architecture.
+- Before editing, inspect nearby code and follow local conventions.
+- After editing, run the most relevant available tests/checks.
+- If tests cannot be run, explain exactly why.
+- Avoid speculative cleanup unrelated to the requested task.
+
+## Important files
+
+- `composer.json`: package metadata, PHP constraint, dependencies, and PSR-4 autoloading.
+- `composer.lock`: locked dependency versions. Keep it consistent with `composer.json`.
+- `classes/`: public library classes.
+- `tests/`: PHPUnit tests.
+- `phpunit.xml`: default PHPUnit config.
+- `conf/phpunit-github.xml`: PHPUnit config used to exclude HTTP-group tests in CI-like runs.
+- `phpstan.neon.dist`: base PHPStan configuration.
+- `conf/phpstan.webmozart-assert.neon`: PHPStan config used by `blast.sh phpstan`.
+- `blast.sh`: development helper; use Git Bash explicitly from Windows PowerShell.
+- `.github/workflows/polish-the-code.yml`: CI workflow for Composer/PHPUnit/PHPStan plus formatting/linting jobs.
+- `.github/linters/phpcs.xml`: PSR-12 PHPCS config used by CI tooling.
+- `sql/poi.sql`: database schema expected by geo/POI helpers.
+- `docs/AI_MAINTENANCE_MAP.md`: architecture and public API map for future agents.
+- `docs/AI_MAINTENANCE_BACKLOG.md`: prioritized maintenance backlog.
+- `CHANGELOG.md`: release notes; update it for notable documentation, behavior, or tooling changes.
+
+## Release / versioning notes
+
+`CHANGELOG.md` says the project follows Keep a Changelog and Semantic Versioning. Releases appear to be GitHub/Packagist tags matching changelog versions. Public API compatibility matters for all classes in `classes/`, because they are directly autoloaded by Composer.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ Missing local aliases/tools:
 - Namespace tests as `WorkOfStan\Backyard\Tests` and place them in `tests/`.
 - Follow the existing PSR-12-ish formatting and the local preference for `array()` syntax.
 - Many public methods are intentionally loosely typed for compatibility. Add native parameter or return types only when the compatibility impact is clear.
-- Preserve existing comments. Remove a TODO only when you actually solve it; translating comments to English is acceptable when meaning is preserved.
+- Preserve existing comments. Remove a `TODO` only when you actually solve it; translating comments to English is acceptable when meaning is preserved.
 - Error handling is mixed: some methods throw built-in exceptions, some return `false` or `0`, and some log, echo, send headers, `exit`, or `die`. Preserve current behavior unless the task explicitly asks to change it.
 - Avoid new runtime dependencies unless clearly justified. Prefer standard PHP and existing Composer dependencies.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed` for changes in existing functionality
 
+- `BackyardMysqli` now accepts an optional connection charset argument, and `Backyard::newMysqli()` forwards it.
+
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added` for new features
 
-- Added AI maintenance documentation and root `AGENTS.md` guidance for future coding agents.
-
 ### `Changed` for changes in existing functionality
-
-- `BackyardMysqli` now accepts an optional connection charset argument, and `Backyard::newMysqli()` forwards it.
 
 ### `Deprecated` for soon-to-be removed features
 
@@ -22,6 +18,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed` for any bugfixes
 
 ### `Security` in case of vulnerabilities
+
+## [4.1.3] - 2026-04-27
+
+feat: add charset option to `BackyardMysqli`
+
+### Added
+
+- Added AI maintenance documentation and root `AGENTS.md` guidance for future coding agents.
+
+### Changed
+
+- `BackyardMysqli` now accepts an optional connection charset argument, and `Backyard::newMysqli()` forwards it.
 
 ## [4.1.2.2] - 2026-03-08
 
@@ -395,7 +403,8 @@ LIBrary in backyard 2.0.0
 
 - fix for post functionality in backyard_getData
 
-[Unreleased]: https://github.com/WorkOfStan/backyard/compare/v4.1.2.2...HEAD
+[Unreleased]: https://github.com/WorkOfStan/backyard/compare/v4.1.3...HEAD
+[4.1.3]: https://github.com/WorkOfStan/backyard/compare/v4.1.2.2...v4.1.3
 [4.1.2.2]: https://github.com/WorkOfStan/backyard/compare/v4.1.2.1...v4.1.2.2
 [4.1.2.1]: https://github.com/WorkOfStan/backyard/compare/v4.1.2...v4.1.2.1
 [4.1.2]: https://github.com/WorkOfStan/backyard/compare/v4.1.1...v4.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added` for new features
 
+- Added AI maintenance documentation and root `AGENTS.md` guidance for future coding agents.
+
 ### `Changed` for changes in existing functionality
 
 ### `Deprecated` for soon-to-be removed features

--- a/classes/Backyard.php
+++ b/classes/Backyard.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WorkOfStan\Backyard;
 
 class Backyard

--- a/classes/Backyard.php
+++ b/classes/Backyard.php
@@ -49,10 +49,11 @@ class Backyard
      * @param string $user
      * @param string $pass
      * @param string $db
+     * @param string $charset
      * @return \WorkOfStan\Backyard\BackyardMysqli
      */
-    public function newMysqli($host_port, $user, $pass, $db)
+    public function newMysqli($host_port, $user, $pass, $db, $charset = 'utf8')
     {
-        return new BackyardMysqli($host_port, $user, $pass, $db, $this->BackyardError);
+        return new BackyardMysqli($host_port, $user, $pass, $db, $this->BackyardError, $charset);
     }
 }

--- a/classes/BackyardArray.php
+++ b/classes/BackyardArray.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WorkOfStan\Backyard;
 
 use Psr\Log\LoggerInterface;

--- a/classes/BackyardBriefApiClient.php
+++ b/classes/BackyardBriefApiClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WorkOfStan\Backyard;
 
 use Psr\Log\LoggerInterface;

--- a/classes/BackyardCrypt.php
+++ b/classes/BackyardCrypt.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WorkOfStan\Backyard;
 
 use Psr\Log\LoggerInterface;

--- a/classes/BackyardError.php
+++ b/classes/BackyardError.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WorkOfStan\Backyard;
 
 use Psr\Log\LoggerInterface;

--- a/classes/BackyardGeo.php
+++ b/classes/BackyardGeo.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WorkOfStan\Backyard;
 
 use InvalidArgumentException;

--- a/classes/BackyardHttp.php
+++ b/classes/BackyardHttp.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WorkOfStan\Backyard;
 
 use Psr\Log\LoggerInterface;

--- a/classes/BackyardJson.php
+++ b/classes/BackyardJson.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WorkOfStan\Backyard;
 
 use Psr\Log\LoggerInterface;

--- a/classes/BackyardMysqli.php
+++ b/classes/BackyardMysqli.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WorkOfStan\Backyard;
 
 use Psr\Log\NullLogger;
@@ -72,6 +74,9 @@ class BackyardMysqli extends \mysqli
         }
 
         //change character set to utf8
+        // todo this condition should enforce at least some utf8, but it also enforces utf8 over utf8mb4. 
+        // Is there a way to see what utf8 is the table already counting on and then enforce the proper utf8 
+        // communication? Or would it be safer for backward compatibility to add it as another argument to constructor?
         if (!$this->set_charset("utf8")) {
             $this->logger->log(2, sprintf("Error loading character set utf8: %s\n", $this->error));
         }

--- a/classes/BackyardMysqli.php
+++ b/classes/BackyardMysqli.php
@@ -74,8 +74,8 @@ class BackyardMysqli extends \mysqli
         }
 
         //change character set to utf8
-        // todo this condition should enforce at least some utf8, but it also enforces utf8 over utf8mb4. 
-        // Is there a way to see what utf8 is the table already counting on and then enforce the proper utf8 
+        // todo this condition should enforce at least some utf8, but it also enforces utf8 over utf8mb4.
+        // Is there a way to see what utf8 is the table already counting on and then enforce the proper utf8
         // communication? Or would it be safer for backward compatibility to add it as another argument to constructor?
         if (!$this->set_charset("utf8")) {
             $this->logger->log(2, sprintf("Error loading character set utf8: %s\n", $this->error));

--- a/classes/BackyardMysqli.php
+++ b/classes/BackyardMysqli.php
@@ -75,6 +75,7 @@ class BackyardMysqli extends \mysqli
         }
 
         //change character set
+        $this->logger->log(5, sprintf("BackyardMysqli set charset %s", $charset));
         if (!$this->set_charset($charset)) {
             $this->logger->log(2, sprintf("Error loading character set %s: %s\n", $charset, $this->error));
         }

--- a/classes/BackyardMysqli.php
+++ b/classes/BackyardMysqli.php
@@ -23,7 +23,7 @@ class BackyardMysqli extends \mysqli
 
     /**
      * \mysqli wrapper with logger
-     * Sets the connection charset to utf-8 and collation to utf8_general_ci
+     * Sets the connection charset to utf8 by default
      *
      * @param string $host_port accepts either hostname (or IPv4) or hostname:port
      * To open as persistent use: $connection = new backyard_mysqli('p:' . $dbhost, $dbuser, $dbpass, $dbname);
@@ -31,10 +31,11 @@ class BackyardMysqli extends \mysqli
      * @param string $pass password
      * @param string $db database name
      * @param BackyardError|null $logger PSR-3 logger
+     * @param string $charset MySQL connection charset
      *
      * @todo add IPv6 , e.g ::1 as $host_port
      */
-    public function __construct($host_port, $user, $pass, $db, ?BackyardError $logger = null)
+    public function __construct($host_port, $user, $pass, $db, ?BackyardError $logger = null, $charset = 'utf8')
     {
         //error_log("debug: " . __CLASS__ . ' ' . __METHOD__);
         $this->logger = is_null($logger) ? new NullLogger() : $logger;
@@ -73,12 +74,9 @@ class BackyardMysqli extends \mysqli
             );
         }
 
-        //change character set to utf8
-        // todo this condition should enforce at least some utf8, but it also enforces utf8 over utf8mb4.
-        // Is there a way to see what utf8 is the table already counting on and then enforce the proper utf8
-        // communication? Or would it be safer for backward compatibility to add it as another argument to constructor?
-        if (!$this->set_charset("utf8")) {
-            $this->logger->log(2, sprintf("Error loading character set utf8: %s\n", $this->error));
+        //change character set
+        if (!$this->set_charset($charset)) {
+            $this->logger->log(2, sprintf("Error loading character set %s: %s\n", $charset, $this->error));
         }
     }
 

--- a/classes/BackyardString.php
+++ b/classes/BackyardString.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WorkOfStan\Backyard;
 
 use Psr\Log\LoggerInterface;

--- a/classes/BackyardTime.php
+++ b/classes/BackyardTime.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WorkOfStan\Backyard;
 
 use Seablast\Logger\LoggerTime;

--- a/classes/HTMLPage.php
+++ b/classes/HTMLPage.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Project: LIB/Part of Library In Backyard
  * Purpose:
@@ -52,6 +50,8 @@ declare(strict_types=1);
  * - consider adding Tracy\Debugger and Tracy\ILogger (PHP>=5.3) instead of error_log
  *
  ***********************************************/
+
+declare(strict_types=1);
 
 namespace WorkOfStan\Backyard;
 

--- a/classes/HTMLPage.php
+++ b/classes/HTMLPage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Project: LIB/Part of Library In Backyard
  * Purpose:

--- a/docs/AI_MAINTENANCE_BACKLOG.md
+++ b/docs/AI_MAINTENANCE_BACKLOG.md
@@ -1,0 +1,129 @@
+# AI Maintenance Backlog
+
+## Critical
+
+### cURL helpers disable SSL verification
+
+- Affected files: `classes/BackyardHttp.php`, `classes/BackyardBriefApiClient.php`
+- Why it matters: `CURLOPT_SSL_VERIFYPEER` is false and `CURLOPT_SSL_VERIFYHOST` is `0`, which accepts invalid certificates and can expose callers to man-in-the-middle attacks.
+- Suggested safe approach: document the current behavior first, then add an opt-in config/parameter for strict verification with tests. Changing the default should be considered separately because it may break existing users with private certificates.
+- Breaking or non-breaking: adding an opt-in strict mode is non-breaking; changing defaults may be breaking.
+- Tests should be added: yes, at least unit tests around option selection; integration tests can use a controlled endpoint.
+
+### SQL identifiers are interpolated from parameters/configuration
+
+- Affected files: `classes/BackyardMysqli.php`, `classes/BackyardGeo.php`
+- Why it matters: `nextIncrement()` interpolates table and column names, and `BackyardGeo` interpolates `geo_poi_list_table_name`. Values are partly cast/sanitized, but identifiers are not centrally validated.
+- Suggested safe approach: add tests that lock current SQL generation, then introduce a small identifier validator for table/column names where safe. Treat any stricter behavior as compatibility-sensitive.
+- Breaking or non-breaking: potentially breaking if existing callers pass unusual identifiers.
+- Tests should be added: yes.
+
+### Required PHP extensions are underdeclared
+
+- Affected files: `composer.json`, `classes/BackyardMysqli.php`, `classes/BackyardHttp.php`
+- Why it matters: Composer declares `ext-curl`, but optional public APIs also use `mysqli`, `sockets`, `mbstring`, and `iconv`. Consumers can install successfully and then hit fatal errors when using those classes or methods.
+- Suggested safe approach: document class-specific extension requirements first. Consider `suggest` entries for optional helpers, or add hard `ext-*` requirements only in a major/compatibility-reviewed release.
+- Breaking or non-breaking: documentation or `suggest` is non-breaking; hard requirements can be breaking for installs.
+- Tests should be added: no direct tests required, but CI should cover extension availability if constraints change.
+
+## High value
+
+### Replace remote HTTP tests with deterministic tests
+
+- Affected files: `tests/BackyardHttpTest.php`, `tests/BackyardJsonTest.php`
+- Why it matters: tests call external URLs and are skipped on GitHub Actions. Results can change due to network, DNS, remote content, or HTTP headers.
+- Suggested safe approach: add a local test server/fake transport or isolate response parsing into testable code. Keep remote tests as optional integration tests if still valuable.
+- Breaking or non-breaking: non-breaking.
+- Tests should be added: yes.
+
+### Add missing tests for geo behavior
+
+- Affected files: `classes/BackyardGeo.php`, new or existing tests under `tests/`
+- Why it matters: distance calculations and POI result shapes are public behavior, but there are no tests.
+- Suggested safe approach: start with pure tests for `getRoughDistance()` and `calculateDistanceFromLatLong()`. Then test `getClosestPOI()` with a safe fake or test double around database access.
+- Breaking or non-breaking: non-breaking.
+- Tests should be added: yes.
+
+### Add missing tests for API client behavior
+
+- Affected files: `classes/BackyardBriefApiClient.php`, new or existing tests under `tests/`
+- Why it matters: this class performs network calls, logs files, decodes JSON, and throws/returns sentinels, but none of that is covered.
+- Suggested safe approach: add tests with a local fake HTTP endpoint or refactor minimally to isolate the transport after behavior is pinned.
+- Breaking or non-breaking: non-breaking if tests only document existing behavior.
+- Tests should be added: yes.
+
+### Add tests around global/header/termination behavior
+
+- Affected files: `classes/BackyardHttp.php`, `classes/BackyardJson.php`, `classes/BackyardError.php`, `classes/HTMLPage.php`
+- Why it matters: public methods call `header()`, echo output, flush buffers, `exit`, and `die`. These behaviors are fragile and easy for agents to break accidentally.
+- Suggested safe approach: test non-terminating modes first, use output buffering, and isolate methods that can be called without `exit`/`die`.
+- Breaking or non-breaking: non-breaking.
+- Tests should be added: yes.
+
+### Add local Composer script aliases
+
+- Affected files: `composer.json`
+- Why it matters: there is no `composer test` or `composer analyse`, so future agents must know tool paths and platform-specific script usage.
+- Suggested safe approach: add only aliases for commands that already work after `composer install`, such as `test` for PHPUnit. Do not make PHPStan a script until its dependency strategy is decided.
+- Breaking or non-breaking: non-breaking.
+- Tests should be added: no, but run `composer validate` and the aliased command.
+
+## Medium value
+
+### Clarify README requirements for current major versions
+
+- Affected files: `README.md`
+- Why it matters: the README still opens with an old PHP 5.3 requirement before listing current 4.x constraints, which can confuse users and agents.
+- Suggested safe approach: reword the requirements section to make current 4.x support (`>=7.4 <8.6`) primary and keep legacy 3.x notes separately.
+- Breaking or non-breaking: non-breaking.
+- Tests should be added: no.
+
+### Improve error-handling documentation and consistency
+
+- Affected files: `classes/*.php`, `README.md`, `docs/AI_MAINTENANCE_MAP.md`
+- Why it matters: methods mix exceptions, `false`, `0`, logging, echo, `exit`, and `die`. This is maintainable only if documented and tested.
+- Suggested safe approach: add docblocks/tests first. Change behavior only when explicitly requested.
+- Breaking or non-breaking: docs/tests are non-breaking; behavior changes may be breaking.
+- Tests should be added: yes for each clarified behavior.
+
+### Reduce PHPStan ignores by adding precise types/docblocks
+
+- Affected files: `phpstan.neon.dist`, `classes/*.php`
+- Why it matters: PHPStan runs at max level with several ignores. Better local types can reduce future false positives and make agent changes safer.
+- Suggested safe approach: handle one class at a time, prefer docblocks over native signatures where compatibility is uncertain, and run PHPStan after each slice.
+- Breaking or non-breaking: usually non-breaking with docblocks; native signatures may be breaking.
+- Tests should be added: only where behavior is touched.
+
+### Translate or repair legacy comments carefully
+
+- Affected files: `classes/*.php`, `README.md`, `CHANGELOG.md`
+- Why it matters: several comments contain Czech text and mojibake-looking encoding, which makes maintenance harder.
+- Suggested safe approach: translate comments to English only when meaning is clear. Never remove comments just for cleanup.
+- Breaking or non-breaking: non-breaking.
+- Tests should be added: no.
+
+### Document `sql/poi.sql` expectations in user-facing docs
+
+- Affected files: `sql/README.md`, `README.md`, `docs/AI_MAINTENANCE_MAP.md`
+- Why it matters: `BackyardGeo` depends on specific POI table columns, but users need to discover that from SQL/source.
+- Suggested safe approach: add a short schema note and link to `sql/poi.sql`.
+- Breaking or non-breaking: non-breaking.
+- Tests should be added: no.
+
+## Low value
+
+### Add `.editorconfig`
+
+- Affected files: new `.editorconfig`
+- Why it matters: helps editors preserve indentation and line endings consistently.
+- Suggested safe approach: mirror the dominant PHP/Markdown style and avoid reformatting existing files in the same change.
+- Breaking or non-breaking: non-breaking.
+- Tests should be added: no.
+
+### Add focused examples for common helper usage
+
+- Affected files: `README.md`, possibly new `examples/`
+- Why it matters: examples would reduce guesswork for facade setup, JSON fetches, MySQL connection, and geo lookup.
+- Suggested safe approach: add small examples that reflect tested behavior and do not require real credentials.
+- Breaking or non-breaking: non-breaking.
+- Tests should be added: optional.

--- a/docs/AI_MAINTENANCE_BACKLOG.md
+++ b/docs/AI_MAINTENANCE_BACKLOG.md
@@ -70,10 +70,10 @@
 
 ## Medium value
 
-### Clarify README requirements for current major versions
+### Clarify readme requirements for current major versions
 
 - Affected files: `README.md`
-- Why it matters: the README still opens with an old PHP 5.3 requirement before listing current 4.x constraints, which can confuse users and agents.
+- Why it matters: the readme still opens with an old PHP 5.3 requirement before listing current 4.x constraints, which can confuse users and agents.
 - Suggested safe approach: reword the requirements section to make current 4.x support (`>=7.4 <8.6`) primary and keep legacy 3.x notes separately.
 - Breaking or non-breaking: non-breaking.
 - Tests should be added: no.

--- a/docs/AI_MAINTENANCE_MAP.md
+++ b/docs/AI_MAINTENANCE_MAP.md
@@ -45,7 +45,7 @@ Conservative rule for future agents: every class in `classes/` is Composer-autol
   - `getJsonArray($json): array`
   - `getArrayArray(array $arr): array`
 - Input/output expectations: sends JSON to a configured URL; may write request/response JSON files under `$appLogFolder`; returns raw cURL result, `false`, arrays, or throws.
-- Breaking-change risk: high for HTTP behavior, supported verbs, logging file names, and empty-array-on-decode-failure behavior.
+- Breaking-change risk: high for HTTP behavior, supported verbs, logging filenames, and empty-array-on-decode-failure behavior.
 
 ### `WorkOfStan\Backyard\BackyardCrypt`
 
@@ -239,7 +239,7 @@ Underdocumented areas:
 - Composer PHP constraint: `>=7.4 <8.6`.
 - CI matrix in `.github/workflows/polish-the-code.yml`: PHP 7.4 through 8.5.
 - Runtime dependencies: `ext-curl`, `seablast/logger`.
-- Lock-file runtime packages observed: `psr/log`, `seablast/logger`, `tracy/tracy`.
+- Lockfile runtime packages observed: `psr/log`, `seablast/logger`, `tracy/tracy`.
 - Dev dependencies: PHPUnit and Webmozart Assert.
 - Additional extensions used by optional classes/methods but not declared in `composer.json`: `mysqli`, `sockets`, `mbstring`, and likely `iconv`.
 - No `declare(strict_types=1)` is used.
@@ -340,7 +340,7 @@ Safe changes:
 - Documentation improvements.
 - Adding focused tests for existing behavior.
 - Local refactors with no public API or behavior changes.
-- Bug fixes with regression tests.
+- Bugfixes with regression tests.
 - Translating comments to English when meaning is preserved.
 - Adding Composer scripts only when they invoke already-existing tools and do not change dependencies or runtime behavior.
 

--- a/docs/AI_MAINTENANCE_MAP.md
+++ b/docs/AI_MAINTENANCE_MAP.md
@@ -1,0 +1,354 @@
+# AI Maintenance Map
+
+## 1. Library purpose
+
+`workofstan/backyard` is a PHP utility library. In practical terms, it provides a facade (`Backyard`) that wires together helper classes for arrays, JSON, HTTP/cURL, logging/error handling, simple random IDs, string transliteration, time measurement, MySQL access, geo/POI distance lookup, and legacy HTML/WML page output.
+
+This is a library, not a standalone application. There is no `src/` directory; Composer autoloads `classes/` as `WorkOfStan\Backyard\`.
+
+## 2. Public API
+
+Conservative rule for future agents: every class in `classes/` is Composer-autoloaded and should be treated as public API unless the project later marks it `@internal`. Changing class names, namespaces, constructor signatures, method names, public properties, return shapes, exception behavior, or side effects can break downstream users.
+
+### `WorkOfStan\Backyard\Backyard`
+
+- File: `classes/Backyard.php`
+- Responsibility: facade/container that creates the core helper objects.
+- Main API:
+  - `__construct(array $backyardConfConstruct = array())`
+  - `newMysqli($host_port, $user, $pass, $db)`
+  - Public properties: `BackyardArray`, `BackyardError`, `BackyardTime`, `Crypt`, `Geo`, `Http`, `Json`, `PageTimestamp`
+- Input/output expectations: accepts a configuration array; constructs helper instances sharing `BackyardError`; `newMysqli()` returns `BackyardMysqli`.
+- Breaking-change risk: high. Public property names and object wiring are likely used directly by consumers.
+
+### `WorkOfStan\Backyard\BackyardArray`
+
+- File: `classes/BackyardArray.php`
+- Responsibility: array utility methods with optional PSR-3 logging.
+- Main methods:
+  - `inArrayWildcards($needle, array $haystack): bool`
+  - `getOneColumnFromArray(array $myArray, $columnName, $columnAlwaysExpected = false): array`
+  - `removeOneColumnFromArray(array $myArray, $columnName): array`
+  - `dumpArrayAsOneLine(array $myArray): string`
+  - `arrayVlookup($searchedValue, array $searchedArray, $columnName, $allExactMatches = false, $columnAlwaysExpected = true): array|false`
+  - `arrayDiffAssocRecursive(array $array1, array $array2): array|int`
+- Input/output expectations: accepts PHP arrays, mostly loose scalar column names and values; logs missing columns when requested; returns arrays, `false`, or `0` depending on method.
+- Breaking-change risk: medium to high. Return sentinels (`false`, `0`) are part of current behavior.
+
+### `WorkOfStan\Backyard\BackyardBriefApiClient`
+
+- File: `classes/BackyardBriefApiClient.php`
+- Responsibility: very small JSON REST client around cURL.
+- Main methods:
+  - `__construct($apiUrl, $appLogFolder = null, ?LoggerInterface $logger = null)`
+  - `sendJsonLoad($json, $httpVerb = 'POST')`
+  - `getJsonArray($json): array`
+  - `getArrayArray(array $arr): array`
+- Input/output expectations: sends JSON to a configured URL; may write request/response JSON files under `$appLogFolder`; returns raw cURL result, `false`, arrays, or throws.
+- Breaking-change risk: high for HTTP behavior, supported verbs, logging file names, and empty-array-on-decode-failure behavior.
+
+### `WorkOfStan\Backyard\BackyardCrypt`
+
+- File: `classes/BackyardCrypt.php`
+- Responsibility: generates custom-length random-looking IDs.
+- Main method: `randomId($randomIdLength = 10): string`
+- Input/output expectations: accepts desired length; recursively extends generated material if needed; logs the generated ID at debug level.
+- Breaking-change risk: medium. Output length is tested; exact character distribution is not.
+
+### `WorkOfStan\Backyard\BackyardError`
+
+- File: `classes/BackyardError.php`
+- Responsibility: wraps `Seablast\Logger\Logger` and adds `dieGraciously()`.
+- Main methods:
+  - `__construct(array $backyardConfConstruct = array(), ?LoggerTime $backyardTime = null)`
+  - `log($level, $message, array $context = array()): void`
+  - `dieGraciously($errorNumber, $errorString, $feedbackButtonMarkup = ''): void`
+- Input/output expectations: merges config defaults, delegates logging to the parent logger, updates global `$RUNNING_TIME`, and `dieGraciously()` writes output then terminates execution.
+- Breaking-change risk: high. Logging configuration keys, global side effects, and termination behavior may be relied on.
+
+### `WorkOfStan\Backyard\BackyardGeo`
+
+- File: `classes/BackyardGeo.php`
+- Responsibility: distance calculations and closest point-of-interest lookup using a `BackyardMysqli` connection.
+- Main methods:
+  - `getRoughDistance($clientLng, $clientLat, $poiLng, $poiLat): float`
+  - `getClosestPOI($lat, $long, $poiCategory, BackyardMysqli $poiConnection): array|false`
+  - `getListOfPOI($poiCategory, BackyardMysqli $poiConnection): array|false`
+  - `calculateDistanceFromLatLong($point1, $point2, $uom = 'km'): float`
+- Input/output expectations: config keys include `geo_rough_distance_limit`, `geo_maximum_meters_from_poi`, and `geo_poi_list_table_name`; POI rows are expected to include `poi_id`, `category`, `mesto`, `PSC`, `adresa`, `long`, and `lat`.
+- Breaking-change risk: high. Return array keys and SQL expectations are observable API.
+
+### `WorkOfStan\Backyard\BackyardHttp`
+
+- File: `classes/BackyardHttp.php`
+- Responsibility: HTTP helper methods for redirects, request parameter lookup, current URL construction, cURL fetches, and socket-based HTTP status checks.
+- Main API:
+  - Constant: `LOG_LEVEL`
+  - `movePage($num, $url, $stopCodeExecution = true): void`
+  - `retrieveFromPostThenGet($nameOfTheParameter): string|false`
+  - `getCurPageURL($includeTheQueryPart = true): string`
+  - `getData($url, $useragent = 'PHP/cURL', $timeout = 5, $customHeaders = false, array $postArray = array(), $customRequest = null): array`
+  - `getHTTPstatusCode($URL_STRING): int|string`
+  - `getHTTPstatusCodeByUA($URL_STRING, $userAgent = 'GetStatusCode/1.1'): int`
+  - Namespaced fallback function: `WorkOfStan\Backyard\apache_request_headers()`
+- Input/output expectations: uses `$_GET`, `$_POST`, `$_SERVER`, `header()`, `exit`, cURL, sockets, and DNS. `getData()` returns an associative array with keys such as `HTTP_CODE`, `message_body`, `HEADER_FIELDS`, `CONTENT_TYPE`, and optionally `REDIRECT_URL`.
+- Breaking-change risk: high. Header output, process termination, returned array shape, and network behavior are externally visible.
+
+### `WorkOfStan\Backyard\BackyardJson`
+
+- File: `classes/BackyardJson.php`
+- Responsibility: JSON minification, JSON output, comment-stripping decode, and JSON-over-HTTP retrieval.
+- Main methods:
+  - `minifyJSON(string $jsonInput, int $logLevel = 5): string`
+  - `outputJSON($jsonString, $exitAfterOutput = false, $logLevel = 5): string`
+  - `jsonCleanDecode($json2decode, $assoc = false, $depth = 512, $options = 0): array|false`
+  - `getJsonAsArray($url, $useragent = 'PHP/cURL', $timeout = 5, $customHeaders = false, array $postArray = array()): array|false`
+- Input/output expectations: invalid JSON is logged and may return the literal error JSON string; `outputJSON()` sends headers, echoes content, and may exit.
+- Breaking-change risk: high for return sentinels, headers, and error JSON format.
+
+### `WorkOfStan\Backyard\BackyardMysqli`
+
+- File: `classes/BackyardMysqli.php`
+- Responsibility: `mysqli` subclass with logging, UTF-8 charset setup, array conversion, and a helper for next numeric IDs.
+- Main methods:
+  - `__construct($host_port, $user, $pass, $db, ?BackyardError $logger = null)`
+  - `query($sql, $errorLogOutput = 1)`
+  - `queryArray($sql, $justOneRow = false): array|false`
+  - `nextIncrement($table, $metricDimension, $primaryDimension = '', $primaryDimensionValue = 0): int`
+- Input/output expectations: `$host_port` may contain `host:port` or `p:host:port`; connection charset is set to `utf8`; query failures are logged; connection failures may call `dieGraciously()` if the logger is `BackyardError`.
+- Breaking-change risk: very high. It extends a PHP internal class and intentionally avoids stricter signatures for compatibility.
+
+### `WorkOfStan\Backyard\BackyardString`
+
+- File: `classes/BackyardString.php`
+- Responsibility: string transliteration helper.
+- Main method: `stripDiacritics($string): string`
+- Input/output expectations: maps a fixed Czech/Slovak-ish character table to ASCII equivalents.
+- Breaking-change risk: medium. Encoding behavior appears legacy and is tested.
+
+### `WorkOfStan\Backyard\BackyardTime`
+
+- File: `classes/BackyardTime.php`
+- Responsibility: project alias/subclass of `Seablast\Logger\LoggerTime`.
+- Main methods: none declared locally; tests call inherited `getRunningTime()` and `pageGeneratedIn()`, and `Backyard` calls inherited `getPageTimestamp()`.
+- Input/output expectations: inherited from `seablast/logger`.
+- Breaking-change risk: medium to high. Changing the parent class or constructor behavior can break facade initialization and time tests.
+
+### `WorkOfStan\Backyard\HTMLPage`
+
+- File: `classes/HTMLPage.php`
+- Responsibility: legacy HTML/WML page generation.
+- Main API:
+  - Public properties: `contentType`, `header`, `footer`, `body`
+  - `__construct($TITLE = 'Backyard rocks', $CONTENT_TYPE = 'text/html', $LOAD_JQ = 1, $LOAD_STYLE = 1, $LOAD_JQUERYMOBILE = 0, $beforeViewport = '', $manifestCache = '')`
+  - `startPage(): void`
+  - `outputCurrentBody(): void`
+  - `endPage(): void`
+  - `fixXml($text): string`
+  - `addToBody($add): void`
+  - `addToHeader($add): void`
+- Input/output expectations: builds HTML/WML strings, sends `Content-Type` headers, echoes body/footer, flushes buffers, and may load old jQuery/jQuery Mobile URLs.
+- Breaking-change risk: high for generated markup and public properties, even though comments label it legacy.
+
+### Data/schema files
+
+- `sql/poi.sql` and `sql/README.md` document the POI table structure expected by `BackyardGeo`.
+- `.htaccess` is deployment hardening for hiding repository, Composer, SQL, Markdown, Neon, shell, and YAML files when the package is exposed under Apache.
+
+## 3. Internal components
+
+There are no formal `@internal` classes. Internal-by-convention pieces include:
+
+- `BackyardBriefApiClient::getCommunicationId()` and `logCommunication()`.
+- `HTMLPage::treatForWml()`.
+- Shared logger fields inside helper classes.
+- The exact array shapes returned by `BackyardHttp::getData()` and `BackyardGeo::getClosestPOI()`, although these are effectively public because callers receive them.
+- SQL query strings inside `BackyardGeo` and `BackyardMysqli`.
+
+Future agents should avoid treating private methods as extension points, but should preserve their behavior when changing public methods.
+
+## 4. Data flow / control flow
+
+Typical facade flow:
+
+1. User code includes Composer autoload and creates `new WorkOfStan\Backyard\Backyard($config)`.
+2. `Backyard` creates `BackyardTime`, records `PageTimestamp`, creates `BackyardError`, then creates array, crypt, geo, HTTP, and JSON helpers sharing that logger.
+3. User code calls helpers through public properties, for example `$backyard->Json->minifyJSON(...)`.
+4. Helper methods return values directly, log through PSR-3, or perform side effects such as headers, echo, `exit`, `die`, filesystem logging, cURL calls, socket calls, or database queries.
+
+Direct-use flow:
+
+1. Users may instantiate any helper class directly through PSR-4 autoloading.
+2. Most helpers accept an optional PSR-3 logger; missing loggers usually become `Psr\Log\NullLogger`.
+3. `BackyardJson` needs both a logger and a `BackyardHttp`.
+4. `BackyardGeo` needs a logger, config array, and `BackyardMysqli` connection for POI lookup.
+
+HTTP/JSON flow:
+
+1. `BackyardJson::getJsonAsArray()` calls `BackyardHttp::getData()`.
+2. `getData()` uses cURL and returns a response array.
+3. `BackyardJson` reads `message_body`, strips JSON comments if requested, decodes, logs errors, and returns an array or `false`.
+
+Geo/database flow:
+
+1. User creates `BackyardMysqli` directly or via `Backyard::newMysqli()`.
+2. `BackyardGeo::getClosestPOI()` validates category input, calls `getListOfPOI()`, and receives rows from `BackyardMysqli::queryArray()`.
+3. It computes rough distances, filters by config, computes exact distances with the Haversine formula, sorts, and returns the closest POI array or `false`.
+
+## 5. Extension points
+
+- Config array passed to `Backyard`, `BackyardError`, and `BackyardGeo`.
+- PSR-3 logger injection into helper constructors.
+- `BackyardJson` accepts a `BackyardHttp` instance, allowing replacement with a compatible subclass/object only if it matches the type.
+- `BackyardMysqli` can be created with a custom `host:port` or persistent `p:host:port` string.
+- `BackyardGeo` can use a different POI table through `geo_poi_list_table_name`.
+- `BackyardBriefApiClient` can log request/response bodies to a configured folder.
+- `HTMLPage` constructor flags configure content type, jQuery/jQuery Mobile loading, CSS loading, viewport preamble, and manifest.
+
+There are no interfaces, events, dependency-injection container bindings, service providers, or plugin hooks in this repository.
+
+## 6. Error handling
+
+There are no custom exception classes in this repository.
+
+Built-in exceptions thrown include:
+
+- `InvalidArgumentException` in `BackyardHttp::movePage()` and `BackyardGeo::getClosestPOI()`.
+- `RuntimeException` in `BackyardHttp::retrieveFromPostThenGet()`, `BackyardHttp::getCurPageURL()`, `BackyardHttp::getData()`, and `BackyardBriefApiClient::getArrayArray()`.
+- `UnexpectedValueException` in `BackyardHttp::getHTTPstatusCode()`, `BackyardGeo`, and `BackyardBriefApiClient::getJsonArray()`.
+- Generic `Exception` is declared in some docblocks but not consistently thrown.
+
+Error return values and side effects:
+
+- Many methods return `false` on failure (`queryArray()`, `getJsonAsArray()`, `getClosestPOI()`, `getListOfPOI()`, `retrieveFromPostThenGet()`, `sendJsonLoad()`).
+- `BackyardArray::arrayDiffAssocRecursive()` returns integer `0` when arrays are equal.
+- `BackyardError::dieGraciously()` logs, echoes optional markup, and terminates execution.
+- `BackyardHttp::movePage()` sends headers and exits by default.
+- `BackyardJson::outputJSON()` sends headers, echoes JSON, and may exit.
+- cURL and socket failures are usually logged and converted to return values rather than exceptions.
+
+Underdocumented areas:
+
+- Exact logger configuration inherited from `seablast/logger`.
+- Whether callers should expect exceptions or false values for each failure path.
+- Security implications of disabled cURL SSL verification.
+- Required PHP extensions beyond `ext-curl`.
+
+## 7. Compatibility constraints
+
+- Composer PHP constraint: `>=7.4 <8.6`.
+- CI matrix in `.github/workflows/polish-the-code.yml`: PHP 7.4 through 8.5.
+- Runtime dependencies: `ext-curl`, `seablast/logger`.
+- Lock-file runtime packages observed: `psr/log`, `seablast/logger`, `tracy/tracy`.
+- Dev dependencies: PHPUnit and Webmozart Assert.
+- Additional extensions used by optional classes/methods but not declared in `composer.json`: `mysqli`, `sockets`, `mbstring`, and likely `iconv`.
+- No `declare(strict_types=1)` is used.
+- The code intentionally keeps several signatures loose for PHP and `mysqli` compatibility.
+- Changelog states the project follows Semantic Versioning.
+- Current evidence of compatibility risk: `composer.json` requires `seablast/logger` `^2.0.5`, but `composer.lock` currently records `v2.0.4`.
+
+## 8. Tests
+
+How to run tests after installing dependencies:
+
+```sh
+vendor/bin/phpunit
+```
+
+On Windows PowerShell:
+
+```powershell
+.\vendor\bin\phpunit
+```
+
+To run the GitHub-style PHPUnit config that excludes HTTP-group tests:
+
+```sh
+vendor/bin/phpunit -c conf/phpunit-github.xml
+```
+
+Current coverage strengths:
+
+- Array utilities are covered reasonably well.
+- `BackyardCrypt::randomId()` length behavior is covered.
+- `BackyardString::stripDiacritics()` is covered for known strings.
+- Basic `BackyardTime` inherited timing methods are covered.
+- JSON minification and comment-cleaning decode are covered.
+- `Backyard` facade wiring is lightly covered through `$backyard->Json`.
+
+Weak or missing coverage:
+
+- No tests for `BackyardMysqli`.
+- No tests for `BackyardGeo`.
+- No tests for `BackyardError::log()` or `dieGraciously()`.
+- No tests for `BackyardBriefApiClient`.
+- No tests for `HTMLPage`.
+- Header/exit/die behavior is mostly skipped or untested.
+- HTTP tests depend on remote URLs and are skipped in GitHub Actions.
+- Socket-based HTTP status methods are untested.
+
+Recommended tests to add first:
+
+- Pure unit tests for `BackyardGeo::calculateDistanceFromLatLong()` and `getRoughDistance()`.
+- Unit tests for `BackyardJson::getJsonAsArray()` using a fake `BackyardHttp`.
+- Tests for `BackyardHttp::retrieveFromPostThenGet()` and `getCurPageURL()` with isolated superglobal setup/teardown.
+- Tests for `BackyardBriefApiClient` against a local fake HTTP endpoint or an injectable transport.
+- Tests around `BackyardMysqli` SQL construction should use a safe test database or a refactor that isolates query building first.
+
+## 9. Tooling
+
+Available or documented commands:
+
+```sh
+composer install
+vendor/bin/phpunit
+vendor/bin/phpunit -c conf/phpunit-github.xml
+```
+
+On Windows PowerShell, do not run `blast.sh` directly. Use Git Bash explicitly:
+
+```powershell
+& "C:\Program Files\Git\bin\bash.exe" -lc "./blast.sh phpstan"
+& "C:\Program Files\Git\bin\bash.exe" -lc "./blast.sh phpstan-remove"
+```
+
+Important tooling notes:
+
+- There are no Composer script aliases such as `composer test`.
+- `phpstan.neon.dist` exists, but PHPStan is not a committed/dev dependency in `composer.json`; `blast.sh phpstan` installs `phpstan/phpstan-webmozart-assert` and `phpstan/phpstan-phpunit` temporarily before running analysis.
+- PHPCS config exists at `.github/linters/phpcs.xml`, but PHPCS is not a local Composer dev dependency. CI uses `WorkOfStan/phpcs-fix@v1`.
+- Super-Linter and Prettier are run in GitHub Actions, not through local Composer scripts.
+
+## 10. Risk areas for AI agents
+
+- Public API: all classes in `classes/`, public properties on `Backyard` and `HTMLPage`, and return array shapes.
+- Backward compatibility: loose method signatures and `#[\ReturnTypeWillChange]` in `BackyardMysqli::query()` are intentional compatibility work.
+- Global state: `$_GET`, `$_POST`, `$_SERVER`, global `$RUNNING_TIME`, `header()`, `exit`, `die`, output buffers.
+- Network access: cURL and sockets are used directly; tests depend on remote services.
+- Security-sensitive behavior: disabled SSL verification in cURL helpers; SQL identifier interpolation in `BackyardMysqli::nextIncrement()` and configurable table names in `BackyardGeo`.
+- Filesystem access: API communication logs can write JSON files to `$appLogFolder`.
+- Database behavior: `BackyardMysqli` extends `mysqli`, connects in the constructor, changes charset to `utf8`, and may terminate on connect error.
+- Encoding: comments and string transliteration tables contain legacy/mojibake-looking Czech text; preserve or deliberately translate comments rather than deleting them.
+- Date/time/randomness: `BackyardTime` behavior is inherited; `BackyardCrypt::randomId()` is not cryptographically documented despite its name.
+- Weak tests: geo, MySQL, brief API client, error handling, HTML output, headers, and socket status checks lack coverage.
+- Tooling drift: `composer.json` and `composer.lock` disagree on `seablast/logger`.
+
+## 11. Safe change policy
+
+Safe changes:
+
+- Documentation improvements.
+- Adding focused tests for existing behavior.
+- Local refactors with no public API or behavior changes.
+- Bug fixes with regression tests.
+- Translating comments to English when meaning is preserved.
+- Adding Composer scripts only when they invoke already-existing tools and do not change dependencies or runtime behavior.
+
+Changes requiring extra caution:
+
+- Changing method signatures, parameter defaults, return types, public property names, class names, namespaces, or constants.
+- Changing exceptions, `false`/`0` sentinels, echoed output, headers, `exit`, or `die` behavior.
+- Changing Composer PHP/dependency constraints.
+- Changing default logger, config, cURL, SSL, database charset, SQL, or redirect behavior.
+- Replacing helper classes with a new architecture.
+- Removing comments, especially historical compatibility notes, unless a `TODO` was actually solved or the comment is translated to English.

--- a/tests/BackyardArrayTest.php
+++ b/tests/BackyardArrayTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WorkOfStan\Backyard\Tests;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/BackyardCryptTest.php
+++ b/tests/BackyardCryptTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WorkOfStan\Backyard\Tests;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/BackyardHttpTest.php
+++ b/tests/BackyardHttpTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WorkOfStan\Backyard\Tests;
 
 // use PHPUnit\Framework\Attributes\Group; // available for PHPUnit/10+

--- a/tests/BackyardJsonTest.php
+++ b/tests/BackyardJsonTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WorkOfStan\Backyard\Tests;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/BackyardStringTest.php
+++ b/tests/BackyardStringTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WorkOfStan\Backyard\Tests;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/BackyardTest.php
+++ b/tests/BackyardTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WorkOfStan\Backyard\Tests;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/BackyardTimeTest.php
+++ b/tests/BackyardTimeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WorkOfStan\Backyard\Tests;
 
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
### Added

- Added AI maintenance documentation and root `AGENTS.md` guidance for future coding agents.

### Changed

- `BackyardMysqli` now accepts an optional connection charset argument, and `Backyard::newMysqli()` forwards it.